### PR TITLE
adding max width for tooltip and tests

### DIFF
--- a/css/px-tooltip-sketch.css
+++ b/css/px-tooltip-sketch.css
@@ -30,6 +30,9 @@ Predix branding rules go in px-tooltip-predix.scss, not in this file.
  * Monochromatic (gray10 is darkest, gray1 is lightest)
  */
 /**
+ * Define grey = gray to avoid dev typos
+ */
+/**
  * Buttons
  */
 /**
@@ -586,11 +589,11 @@ a {
 #tooltip {
   outline: none;
   padding: 15px;
-  width: auto;
   background-color: black;
   margin: 15px;
   color: white;
-  white-space: nowrap; }
+  max-width: 400px;
+  white-space: normal; }
   #tooltip h6 {
     margin: 0; }
   #tooltip p {

--- a/css/px-tooltip.css
+++ b/css/px-tooltip.css
@@ -30,6 +30,9 @@ common/abstract rules go in px-tooltip-sketch.scss, not in this file.
  * Monochromatic (gray10 is darkest, gray1 is lightest)
  */
 /**
+ * Define grey = gray to avoid dev typos
+ */
+/**
  * Buttons
  */
 /**
@@ -599,11 +602,11 @@ a {
 #tooltip {
   outline: none;
   padding: 15px;
-  width: auto;
   background-color: black;
   margin: 15px;
   color: white;
-  white-space: nowrap; }
+  max-width: 400px;
+  white-space: normal; }
   #tooltip h6 {
     margin: 0; }
   #tooltip p {

--- a/demo.html
+++ b/demo.html
@@ -52,6 +52,7 @@
                 vertical-align: middle;
                 background-color: gray;
             }
+            
         </style>
     </head>
 
@@ -84,7 +85,7 @@
             <p></p>
             <div id="hoverDivBottom" class="hover-tooltip">Hover for tooltip<br/><span>(HTML element, bottom, default delay: 1 sec)</span></div>
             <px-tooltip for="hoverDivBottom" orientation="bottom">
-                Bottom tooltip<br>with html<br><div class='test-el'>HTML Div</div>
+                    Bottom tooltip<br>with html<br><div class='test-el'>HTML Div</div>
             </px-tooltip>
             <p></p>
             <div id="hoverDivLeft" class="hover-tooltip">Hover for tooltip<br/><span>(left, delay: 3 sec)</span></div>
@@ -104,6 +105,14 @@
 
             <p></p>
             <div id="hoverDivObj" class="hover-tooltip">For is an Element elsewhere in the dom
+            </div>
+
+            <p></p>
+            <div id="hoverDivTop6" class="hover-tooltip">Tooltip contains lots of text
+                <px-tooltip
+                    orientation="top"
+                    tooltip-message="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer imperdiet velit non risus pellentesque, id molestie velit varius. Integer ac nulla hendrerit, aliquet mauris vitae, varius augue. Nulla non turpis metus. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla consectetur tincidunt tincidunt. Suspendisse vitae turpis libero.">
+                </px-tooltip>
             </div>
 
         </div>
@@ -153,6 +162,7 @@
                 </px-tooltip>
             </div>
         </div>
+        
 
         <div class="sample-container-right">
             <div id="hoverDivTop4" class="hover-tooltip">Smart: Hover for tooltip
@@ -163,6 +173,7 @@
                 </px-tooltip>
             </div>
         </div>
+
         <div class="sample-container-right">
             <div id="hoverDivTop5" class="hover-tooltip">Smart: Hover for tooltip
                 <px-tooltip
@@ -172,6 +183,18 @@
                 </px-tooltip>
             </div>
         </div>
+
+        <p></p>
+        <div class="sample-container-left">
+            <div id="hoverDivTop7" class="hover-tooltip">Smart: Hover for big long text tooltip
+                    <px-tooltip
+                        smart-orientation
+                        orientation="right"
+                        tooltip-message="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer imperdiet velit non risus pellentesque, id molestie velit varius. Integer ac nulla hendrerit, aliquet mauris vitae, varius augue. Nulla non turpis metus. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla consectetur tincidunt tincidunt. Suspendisse vitae turpis libero.">
+                    </px-tooltip>
+                </div>
+        </div>
+
 
     </body>
 </html>

--- a/sass/px-tooltip-predix.scss
+++ b/sass/px-tooltip-predix.scss
@@ -27,6 +27,7 @@ common/abstract rules go in px-tooltip-sketch.scss, not in this file.
 #tooltip {
     background-color: $tooltip-color;
     border-radius: 4px;
+
     p {
         margin: 0;
         hyphens: auto;

--- a/sass/px-tooltip-sketch.scss
+++ b/sass/px-tooltip-sketch.scss
@@ -37,6 +37,7 @@ $carat: 7px;
 $border-radius: 4px;
 $tooltip-color: $black;
 $tooltip-text-color: $white;
+$tooltip-max-width: 400px;
 
 :host {
     display: block;
@@ -48,11 +49,12 @@ $tooltip-text-color: $white;
 #tooltip {
     outline: none;
     padding: 15px;
-    width: auto;
     background-color: $tooltip-color;
     margin: $margin;
     color: $tooltip-text-color;
-    white-space: nowrap;
+    max-width: $tooltip-max-width;
+    white-space: normal;
+
     h6 {
         margin: 0;
     }

--- a/test/px-tooltip-custom-tests.js
+++ b/test/px-tooltip-custom-tests.js
@@ -54,8 +54,7 @@ function runCustomTests() {
       test('Check max width of tooltip', function() {
           if (tooltip_text.length > 52){
               assert.equal(width_styles, '400px');
-          }
-        
+          }   
       });
       
   });

--- a/test/px-tooltip-custom-tests.js
+++ b/test/px-tooltip-custom-tests.js
@@ -43,6 +43,24 @@ function runCustomTests() {
    });
   });
 
+  suite('Large text string tooltip', function() {
+      
+      var px_tooltip_large = Polymer.dom(document).querySelector('#px_tooltip_9'),
+          tooltip_text = px_tooltip_large.tooltipMessage,
+          tooltip_classes = Polymer.dom(px_tooltip_large.root).querySelector('#tooltip.px-tooltip'),
+          width_styles = getStyle(tooltip_classes, 'max-width'),
+          boolval = true;
+
+      test('Check max width of tooltip', function() {
+          if (tooltip_text.length > 52){
+              assert.equal(width_styles, '400px');
+          }
+        
+      });
+      
+  });
+
+
 // Object
 suite('Custom Automation Tests for px-tooltip', function() {
   var px_tooltip = Polymer.dom(document).querySelector('#px_tooltip_8')

--- a/test/px-tooltip-test-fixture.html
+++ b/test/px-tooltip-test-fixture.html
@@ -99,5 +99,14 @@
           id="px_tooltip_8">
       </px-tooltip>
     </div>
+
+    <div id="hoverDivTop6" class="hover-tooltip">Hover for large tooltip
+        <px-tooltip
+            orientation="top"
+            tooltip-message="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer imperdiet velit non risus pellentesque, id molestie velit varius. Integer ac nulla hendrerit, aliquet mauris vitae, varius augue. Nulla non turpis metus. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla consectetur tincidunt tincidunt. Suspendisse vitae turpis libero."
+            id="px_tooltip_9">
+        </px-tooltip>
+    </div>
+
   </body>
 </html>


### PR DESCRIPTION
Fix to resolve issue: https://github.com/PredixDev/px-tooltip/issues/7

- [x] Added max-width to px-tooltip-sketch.scss for 400px (smaller than mobile)
- [x] Checked with Px visual design
- [x] Added test for change
- [x] Updated demo


Before change:
![screen shot 2016-05-05 at 3 10-1 28 pm 2](https://cloud.githubusercontent.com/assets/6137443/15123927/ccd52754-15da-11e6-826e-45c87a80dc89.png)

After change: 

![screen shot 2016-05-09 at 11 21 55 am](https://cloud.githubusercontent.com/assets/6137443/15123941/ddadf178-15da-11e6-8696-02ee2ca20356.png)

Tooltips with less text look the same: 
![screen shot 2016-05-09 at 11 22 47 am](https://cloud.githubusercontent.com/assets/6137443/15123937/d84e7c84-15da-11e6-9f60-3dbea9efb431.png)
