### PR TITLE
adding css for long-word wrap

### DIFF
--- a/css/px-tooltip-sketch.css
+++ b/css/px-tooltip-sketch.css
@@ -427,120 +427,149 @@ a {
   visibility: hidden !important; }
 
 .flex {
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex; }
 
 .flex--row {
-  -ms-flex-direction: row;
-      flex-direction: row; }
+  -webkit-flex-direction: row;
+      -ms-flex-direction: row;
+          flex-direction: row; }
 
 .flex--row--rev {
-  -ms-flex-direction: row-reverse;
-      flex-direction: row-reverse; }
+  -webkit-flex-direction: row-reverse;
+      -ms-flex-direction: row-reverse;
+          flex-direction: row-reverse; }
 
 .flex--col {
-  -ms-flex-direction: column;
-      flex-direction: column; }
+  -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+          flex-direction: column; }
 
 .flex--col--rev {
-  -ms-flex-direction: column-reverse;
-      flex-direction: column-reverse; }
+  -webkit-flex-direction: column-reverse;
+      -ms-flex-direction: column-reverse;
+          flex-direction: column-reverse; }
 
 .flex--nowrap {
-  -ms-flex-wrap: nowrap;
-      flex-wrap: nowrap; }
+  -webkit-flex-wrap: nowrap;
+      -ms-flex-wrap: nowrap;
+          flex-wrap: nowrap; }
 
 .flex--wrap {
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap; }
+  -webkit-flex-wrap: wrap;
+      -ms-flex-wrap: wrap;
+          flex-wrap: wrap; }
 
 .flex--wrap--rev {
-  -ms-flex-wrap: wrap-reverse;
-      flex-wrap: wrap-reverse; }
+  -webkit-flex-wrap: wrap-reverse;
+      -ms-flex-wrap: wrap-reverse;
+          flex-wrap: wrap-reverse; }
 
 .flex--left {
-  -ms-flex-pack: start;
-      justify-content: flex-start; }
+  -webkit-justify-content: flex-start;
+      -ms-flex-pack: start;
+          justify-content: flex-start; }
 
 .flex--center {
-  -ms-flex-pack: center;
-      justify-content: center; }
+  -webkit-justify-content: center;
+      -ms-flex-pack: center;
+          justify-content: center; }
 
 .flex--right {
-  -ms-flex-pack: end;
-      justify-content: flex-end; }
+  -webkit-justify-content: flex-end;
+      -ms-flex-pack: end;
+          justify-content: flex-end; }
 
 .flex--justify {
-  -ms-flex-pack: justify;
-      justify-content: space-between; }
+  -webkit-justify-content: space-between;
+      -ms-flex-pack: justify;
+          justify-content: space-between; }
 
 .flex--spaced {
-  -ms-flex-pack: distribute;
-      justify-content: space-around; }
+  -webkit-justify-content: space-around;
+      -ms-flex-pack: distribute;
+          justify-content: space-around; }
 
 .flex--top {
-  -ms-flex-align: start;
-      align-items: flex-start; }
+  -webkit-align-items: flex-start;
+      -ms-flex-align: start;
+          align-items: flex-start; }
 
 .flex--middle {
-  -ms-flex-align: center;
-      align-items: center; }
+  -webkit-align-items: center;
+      -ms-flex-align: center;
+          align-items: center; }
 
 .flex--bottom {
-  -ms-flex-align: end;
-      align-items: flex-end; }
+  -webkit-align-items: flex-end;
+      -ms-flex-align: end;
+          align-items: flex-end; }
 
 .flex--stretch {
-  -ms-flex-align: stretch;
-      align-items: stretch; }
+  -webkit-align-items: stretch;
+      -ms-flex-align: stretch;
+          align-items: stretch; }
 
 .flex--baseline {
-  -ms-flex-align: baseline;
-      align-items: baseline; }
+  -webkit-align-items: baseline;
+      -ms-flex-align: baseline;
+          align-items: baseline; }
 
 .flex--top--multi {
-  -ms-flex-line-pack: start;
-      align-content: flex-start; }
+  -webkit-align-content: flex-start;
+      -ms-flex-line-pack: start;
+          align-content: flex-start; }
 
 .flex--middle--multi {
-  -ms-flex-line-pack: center;
-      align-content: center; }
+  -webkit-align-content: center;
+      -ms-flex-line-pack: center;
+          align-content: center; }
 
 .flex--bottom--multi {
-  -ms-flex-line-pack: end;
-      align-content: flex-end; }
+  -webkit-align-content: flex-end;
+      -ms-flex-line-pack: end;
+          align-content: flex-end; }
 
 .flex--stretch--multi {
-  -ms-flex-line-pack: stretch;
-      align-content: stretch; }
+  -webkit-align-content: stretch;
+      -ms-flex-line-pack: stretch;
+          align-content: stretch; }
 
 .flex--justify--multi {
-  -ms-flex-line-pack: justify;
-      align-content: space-between; }
+  -webkit-align-content: space-between;
+      -ms-flex-line-pack: justify;
+          align-content: space-between; }
 
 .flex--spaced--multi {
-  -ms-flex-line-pack: distribute;
-      align-content: space-around; }
+  -webkit-align-content: space-around;
+      -ms-flex-line-pack: distribute;
+          align-content: space-around; }
 
 .flex__item {
-  -ms-flex: 1;
-      flex: 1; }
+  -webkit-flex: 1;
+      -ms-flex: 1;
+          flex: 1; }
 
 .flex__item--top {
-  -ms-flex-item-align: start;
-      align-self: flex-start; }
+  -webkit-align-self: flex-start;
+      -ms-flex-item-align: start;
+          align-self: flex-start; }
 
 .flex__item--middle {
-  -ms-flex-item-align: center;
-      align-self: center; }
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center; }
 
 .flex__item--bottom {
-  -ms-flex-item-align: end;
-      align-self: flex-end; }
+  -webkit-align-self: flex-end;
+      -ms-flex-item-align: end;
+          align-self: flex-end; }
 
 .flex__item--baseline {
-  -ms-flex-item-align: baseline;
-      align-self: baseline; }
+  -webkit-align-self: baseline;
+      -ms-flex-item-align: baseline;
+          align-self: baseline; }
 
 .viewport {
   width: 100%;
@@ -564,7 +593,8 @@ a {
   margin: 15px;
   color: white;
   max-width: 400px;
-  white-space: normal; }
+  white-space: normal;
+  overflow-wrap: break-word; }
   #tooltip h6 {
     margin: 0; }
   #tooltip p {
@@ -630,391 +660,479 @@ div#carat {
 
 .u-1\/2 {
   width: 50% !important;
-  -ms-flex: none !important;
-      flex: none !important; }
+  -webkit-flex: none !important;
+      -ms-flex: none !important;
+          flex: none !important; }
 
 .u-1\/3 {
   width: 33.3333333333% !important;
-  -ms-flex: none !important;
-      flex: none !important; }
+  -webkit-flex: none !important;
+      -ms-flex: none !important;
+          flex: none !important; }
 
 .u-2\/3 {
   width: 66.6666666667% !important;
-  -ms-flex: none !important;
-      flex: none !important; }
+  -webkit-flex: none !important;
+      -ms-flex: none !important;
+          flex: none !important; }
 
 .u-1\/4 {
   width: 25% !important;
-  -ms-flex: none !important;
-      flex: none !important; }
+  -webkit-flex: none !important;
+      -ms-flex: none !important;
+          flex: none !important; }
 
 .u-2\/4 {
   width: 50% !important;
-  -ms-flex: none !important;
-      flex: none !important; }
+  -webkit-flex: none !important;
+      -ms-flex: none !important;
+          flex: none !important; }
 
 .u-3\/4 {
   width: 75% !important;
-  -ms-flex: none !important;
-      flex: none !important; }
+  -webkit-flex: none !important;
+      -ms-flex: none !important;
+          flex: none !important; }
 
 .u-1\/6 {
   width: 16.6666666667% !important;
-  -ms-flex: none !important;
-      flex: none !important; }
+  -webkit-flex: none !important;
+      -ms-flex: none !important;
+          flex: none !important; }
 
 .u-2\/6 {
   width: 33.3333333333% !important;
-  -ms-flex: none !important;
-      flex: none !important; }
+  -webkit-flex: none !important;
+      -ms-flex: none !important;
+          flex: none !important; }
 
 .u-3\/6 {
   width: 50% !important;
-  -ms-flex: none !important;
-      flex: none !important; }
+  -webkit-flex: none !important;
+      -ms-flex: none !important;
+          flex: none !important; }
 
 .u-4\/6 {
   width: 66.6666666667% !important;
-  -ms-flex: none !important;
-      flex: none !important; }
+  -webkit-flex: none !important;
+      -ms-flex: none !important;
+          flex: none !important; }
 
 .u-5\/6 {
   width: 83.3333333333% !important;
-  -ms-flex: none !important;
-      flex: none !important; }
+  -webkit-flex: none !important;
+      -ms-flex: none !important;
+          flex: none !important; }
 
 @media screen and (max-width: 47.9375rem) {
   .u-1\/1-palm {
     width: 100% !important; }
   .u-1\/2-palm {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/3-palm {
     width: 33.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/3-palm {
     width: 66.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/4-palm {
     width: 25% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/4-palm {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-3\/4-palm {
     width: 75% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/6-palm {
     width: 16.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/6-palm {
     width: 33.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-3\/6-palm {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-4\/6-palm {
     width: 66.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-5\/6-palm {
     width: 83.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; } }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; } }
 
 @media screen and (min-width: 48rem) and (max-width: 68.204166667rem) {
   .u-1\/1-lap {
     width: 100% !important; }
   .u-1\/2-lap {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/3-lap {
     width: 33.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/3-lap {
     width: 66.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/4-lap {
     width: 25% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/4-lap {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-3\/4-lap {
     width: 75% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/6-lap {
     width: 16.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/6-lap {
     width: 33.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-3\/6-lap {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-4\/6-lap {
     width: 66.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-5\/6-lap {
     width: 83.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; } }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; } }
 
 @media screen and (min-width: 48rem) {
   .u-1\/1-lap-and-up {
     width: 100% !important; }
   .u-1\/2-lap-and-up {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/3-lap-and-up {
     width: 33.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/3-lap-and-up {
     width: 66.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/4-lap-and-up {
     width: 25% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/4-lap-and-up {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-3\/4-lap-and-up {
     width: 75% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/6-lap-and-up {
     width: 16.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/6-lap-and-up {
     width: 33.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-3\/6-lap-and-up {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-4\/6-lap-and-up {
     width: 66.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-5\/6-lap-and-up {
     width: 83.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; } }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; } }
 
 @media screen and (max-width: 68.2rem) {
   .u-1\/1-portable {
     width: 100% !important; }
   .u-1\/2-portable {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/3-portable {
     width: 33.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/3-portable {
     width: 66.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/4-portable {
     width: 25% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/4-portable {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-3\/4-portable {
     width: 75% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/6-portable {
     width: 16.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/6-portable {
     width: 33.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-3\/6-portable {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-4\/6-portable {
     width: 66.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-5\/6-portable {
     width: 83.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; } }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; } }
 
 @media screen and (min-width: 68.266666667rem) {
   .u-1\/1-desk {
     width: 100% !important; }
   .u-1\/2-desk {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/3-desk {
     width: 33.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/3-desk {
     width: 66.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/4-desk {
     width: 25% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/4-desk {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-3\/4-desk {
     width: 75% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/6-desk {
     width: 16.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/6-desk {
     width: 33.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-3\/6-desk {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-4\/6-desk {
     width: 66.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-5\/6-desk {
     width: 83.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; } }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; } }
 
 @media screen and (min-width: 80rem) {
   .u-1\/1-desk-wide {
     width: 100% !important; }
   .u-1\/2-desk-wide {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/3-desk-wide {
     width: 33.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/3-desk-wide {
     width: 66.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/4-desk-wide {
     width: 25% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/4-desk-wide {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-3\/4-desk-wide {
     width: 75% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/6-desk-wide {
     width: 16.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/6-desk-wide {
     width: 33.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-3\/6-desk-wide {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-4\/6-desk-wide {
     width: 66.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-5\/6-desk-wide {
     width: 83.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; } }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; } }
 
 @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi), (min-resolution: 2dppx) {
   .u-1\/1-retina {
     width: 100% !important; }
   .u-1\/2-retina {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/3-retina {
     width: 33.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/3-retina {
     width: 66.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/4-retina {
     width: 25% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/4-retina {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-3\/4-retina {
     width: 75% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/6-retina {
     width: 16.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/6-retina {
     width: 33.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-3\/6-retina {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-4\/6-retina {
     width: 66.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-5\/6-retina {
     width: 83.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; } }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; } }

--- a/css/px-tooltip.css
+++ b/css/px-tooltip.css
@@ -440,120 +440,149 @@ a {
   visibility: hidden !important; }
 
 .flex {
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex; }
 
 .flex--row {
-  -ms-flex-direction: row;
-      flex-direction: row; }
+  -webkit-flex-direction: row;
+      -ms-flex-direction: row;
+          flex-direction: row; }
 
 .flex--row--rev {
-  -ms-flex-direction: row-reverse;
-      flex-direction: row-reverse; }
+  -webkit-flex-direction: row-reverse;
+      -ms-flex-direction: row-reverse;
+          flex-direction: row-reverse; }
 
 .flex--col {
-  -ms-flex-direction: column;
-      flex-direction: column; }
+  -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+          flex-direction: column; }
 
 .flex--col--rev {
-  -ms-flex-direction: column-reverse;
-      flex-direction: column-reverse; }
+  -webkit-flex-direction: column-reverse;
+      -ms-flex-direction: column-reverse;
+          flex-direction: column-reverse; }
 
 .flex--nowrap {
-  -ms-flex-wrap: nowrap;
-      flex-wrap: nowrap; }
+  -webkit-flex-wrap: nowrap;
+      -ms-flex-wrap: nowrap;
+          flex-wrap: nowrap; }
 
 .flex--wrap {
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap; }
+  -webkit-flex-wrap: wrap;
+      -ms-flex-wrap: wrap;
+          flex-wrap: wrap; }
 
 .flex--wrap--rev {
-  -ms-flex-wrap: wrap-reverse;
-      flex-wrap: wrap-reverse; }
+  -webkit-flex-wrap: wrap-reverse;
+      -ms-flex-wrap: wrap-reverse;
+          flex-wrap: wrap-reverse; }
 
 .flex--left {
-  -ms-flex-pack: start;
-      justify-content: flex-start; }
+  -webkit-justify-content: flex-start;
+      -ms-flex-pack: start;
+          justify-content: flex-start; }
 
 .flex--center {
-  -ms-flex-pack: center;
-      justify-content: center; }
+  -webkit-justify-content: center;
+      -ms-flex-pack: center;
+          justify-content: center; }
 
 .flex--right {
-  -ms-flex-pack: end;
-      justify-content: flex-end; }
+  -webkit-justify-content: flex-end;
+      -ms-flex-pack: end;
+          justify-content: flex-end; }
 
 .flex--justify {
-  -ms-flex-pack: justify;
-      justify-content: space-between; }
+  -webkit-justify-content: space-between;
+      -ms-flex-pack: justify;
+          justify-content: space-between; }
 
 .flex--spaced {
-  -ms-flex-pack: distribute;
-      justify-content: space-around; }
+  -webkit-justify-content: space-around;
+      -ms-flex-pack: distribute;
+          justify-content: space-around; }
 
 .flex--top {
-  -ms-flex-align: start;
-      align-items: flex-start; }
+  -webkit-align-items: flex-start;
+      -ms-flex-align: start;
+          align-items: flex-start; }
 
 .flex--middle {
-  -ms-flex-align: center;
-      align-items: center; }
+  -webkit-align-items: center;
+      -ms-flex-align: center;
+          align-items: center; }
 
 .flex--bottom {
-  -ms-flex-align: end;
-      align-items: flex-end; }
+  -webkit-align-items: flex-end;
+      -ms-flex-align: end;
+          align-items: flex-end; }
 
 .flex--stretch {
-  -ms-flex-align: stretch;
-      align-items: stretch; }
+  -webkit-align-items: stretch;
+      -ms-flex-align: stretch;
+          align-items: stretch; }
 
 .flex--baseline {
-  -ms-flex-align: baseline;
-      align-items: baseline; }
+  -webkit-align-items: baseline;
+      -ms-flex-align: baseline;
+          align-items: baseline; }
 
 .flex--top--multi {
-  -ms-flex-line-pack: start;
-      align-content: flex-start; }
+  -webkit-align-content: flex-start;
+      -ms-flex-line-pack: start;
+          align-content: flex-start; }
 
 .flex--middle--multi {
-  -ms-flex-line-pack: center;
-      align-content: center; }
+  -webkit-align-content: center;
+      -ms-flex-line-pack: center;
+          align-content: center; }
 
 .flex--bottom--multi {
-  -ms-flex-line-pack: end;
-      align-content: flex-end; }
+  -webkit-align-content: flex-end;
+      -ms-flex-line-pack: end;
+          align-content: flex-end; }
 
 .flex--stretch--multi {
-  -ms-flex-line-pack: stretch;
-      align-content: stretch; }
+  -webkit-align-content: stretch;
+      -ms-flex-line-pack: stretch;
+          align-content: stretch; }
 
 .flex--justify--multi {
-  -ms-flex-line-pack: justify;
-      align-content: space-between; }
+  -webkit-align-content: space-between;
+      -ms-flex-line-pack: justify;
+          align-content: space-between; }
 
 .flex--spaced--multi {
-  -ms-flex-line-pack: distribute;
-      align-content: space-around; }
+  -webkit-align-content: space-around;
+      -ms-flex-line-pack: distribute;
+          align-content: space-around; }
 
 .flex__item {
-  -ms-flex: 1;
-      flex: 1; }
+  -webkit-flex: 1;
+      -ms-flex: 1;
+          flex: 1; }
 
 .flex__item--top {
-  -ms-flex-item-align: start;
-      align-self: flex-start; }
+  -webkit-align-self: flex-start;
+      -ms-flex-item-align: start;
+          align-self: flex-start; }
 
 .flex__item--middle {
-  -ms-flex-item-align: center;
-      align-self: center; }
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center; }
 
 .flex__item--bottom {
-  -ms-flex-item-align: end;
-      align-self: flex-end; }
+  -webkit-align-self: flex-end;
+      -ms-flex-item-align: end;
+          align-self: flex-end; }
 
 .flex__item--baseline {
-  -ms-flex-item-align: baseline;
-      align-self: baseline; }
+  -webkit-align-self: baseline;
+      -ms-flex-item-align: baseline;
+          align-self: baseline; }
 
 .viewport {
   width: 100%;
@@ -577,7 +606,8 @@ a {
   margin: 15px;
   color: white;
   max-width: 400px;
-  white-space: normal; }
+  white-space: normal;
+  overflow-wrap: break-word; }
   #tooltip h6 {
     margin: 0; }
   #tooltip p {
@@ -643,394 +673,482 @@ div#carat {
 
 .u-1\/2 {
   width: 50% !important;
-  -ms-flex: none !important;
-      flex: none !important; }
+  -webkit-flex: none !important;
+      -ms-flex: none !important;
+          flex: none !important; }
 
 .u-1\/3 {
   width: 33.3333333333% !important;
-  -ms-flex: none !important;
-      flex: none !important; }
+  -webkit-flex: none !important;
+      -ms-flex: none !important;
+          flex: none !important; }
 
 .u-2\/3 {
   width: 66.6666666667% !important;
-  -ms-flex: none !important;
-      flex: none !important; }
+  -webkit-flex: none !important;
+      -ms-flex: none !important;
+          flex: none !important; }
 
 .u-1\/4 {
   width: 25% !important;
-  -ms-flex: none !important;
-      flex: none !important; }
+  -webkit-flex: none !important;
+      -ms-flex: none !important;
+          flex: none !important; }
 
 .u-2\/4 {
   width: 50% !important;
-  -ms-flex: none !important;
-      flex: none !important; }
+  -webkit-flex: none !important;
+      -ms-flex: none !important;
+          flex: none !important; }
 
 .u-3\/4 {
   width: 75% !important;
-  -ms-flex: none !important;
-      flex: none !important; }
+  -webkit-flex: none !important;
+      -ms-flex: none !important;
+          flex: none !important; }
 
 .u-1\/6 {
   width: 16.6666666667% !important;
-  -ms-flex: none !important;
-      flex: none !important; }
+  -webkit-flex: none !important;
+      -ms-flex: none !important;
+          flex: none !important; }
 
 .u-2\/6 {
   width: 33.3333333333% !important;
-  -ms-flex: none !important;
-      flex: none !important; }
+  -webkit-flex: none !important;
+      -ms-flex: none !important;
+          flex: none !important; }
 
 .u-3\/6 {
   width: 50% !important;
-  -ms-flex: none !important;
-      flex: none !important; }
+  -webkit-flex: none !important;
+      -ms-flex: none !important;
+          flex: none !important; }
 
 .u-4\/6 {
   width: 66.6666666667% !important;
-  -ms-flex: none !important;
-      flex: none !important; }
+  -webkit-flex: none !important;
+      -ms-flex: none !important;
+          flex: none !important; }
 
 .u-5\/6 {
   width: 83.3333333333% !important;
-  -ms-flex: none !important;
-      flex: none !important; }
+  -webkit-flex: none !important;
+      -ms-flex: none !important;
+          flex: none !important; }
 
 @media screen and (max-width: 47.9375rem) {
   .u-1\/1-palm {
     width: 100% !important; }
   .u-1\/2-palm {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/3-palm {
     width: 33.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/3-palm {
     width: 66.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/4-palm {
     width: 25% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/4-palm {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-3\/4-palm {
     width: 75% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/6-palm {
     width: 16.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/6-palm {
     width: 33.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-3\/6-palm {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-4\/6-palm {
     width: 66.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-5\/6-palm {
     width: 83.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; } }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; } }
 
 @media screen and (min-width: 48rem) and (max-width: 68.204166667rem) {
   .u-1\/1-lap {
     width: 100% !important; }
   .u-1\/2-lap {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/3-lap {
     width: 33.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/3-lap {
     width: 66.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/4-lap {
     width: 25% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/4-lap {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-3\/4-lap {
     width: 75% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/6-lap {
     width: 16.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/6-lap {
     width: 33.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-3\/6-lap {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-4\/6-lap {
     width: 66.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-5\/6-lap {
     width: 83.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; } }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; } }
 
 @media screen and (min-width: 48rem) {
   .u-1\/1-lap-and-up {
     width: 100% !important; }
   .u-1\/2-lap-and-up {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/3-lap-and-up {
     width: 33.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/3-lap-and-up {
     width: 66.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/4-lap-and-up {
     width: 25% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/4-lap-and-up {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-3\/4-lap-and-up {
     width: 75% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/6-lap-and-up {
     width: 16.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/6-lap-and-up {
     width: 33.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-3\/6-lap-and-up {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-4\/6-lap-and-up {
     width: 66.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-5\/6-lap-and-up {
     width: 83.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; } }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; } }
 
 @media screen and (max-width: 68.2rem) {
   .u-1\/1-portable {
     width: 100% !important; }
   .u-1\/2-portable {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/3-portable {
     width: 33.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/3-portable {
     width: 66.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/4-portable {
     width: 25% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/4-portable {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-3\/4-portable {
     width: 75% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/6-portable {
     width: 16.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/6-portable {
     width: 33.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-3\/6-portable {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-4\/6-portable {
     width: 66.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-5\/6-portable {
     width: 83.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; } }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; } }
 
 @media screen and (min-width: 68.266666667rem) {
   .u-1\/1-desk {
     width: 100% !important; }
   .u-1\/2-desk {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/3-desk {
     width: 33.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/3-desk {
     width: 66.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/4-desk {
     width: 25% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/4-desk {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-3\/4-desk {
     width: 75% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/6-desk {
     width: 16.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/6-desk {
     width: 33.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-3\/6-desk {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-4\/6-desk {
     width: 66.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-5\/6-desk {
     width: 83.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; } }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; } }
 
 @media screen and (min-width: 80rem) {
   .u-1\/1-desk-wide {
     width: 100% !important; }
   .u-1\/2-desk-wide {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/3-desk-wide {
     width: 33.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/3-desk-wide {
     width: 66.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/4-desk-wide {
     width: 25% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/4-desk-wide {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-3\/4-desk-wide {
     width: 75% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/6-desk-wide {
     width: 16.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/6-desk-wide {
     width: 33.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-3\/6-desk-wide {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-4\/6-desk-wide {
     width: 66.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-5\/6-desk-wide {
     width: 83.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; } }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; } }
 
 @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi), (min-resolution: 2dppx) {
   .u-1\/1-retina {
     width: 100% !important; }
   .u-1\/2-retina {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/3-retina {
     width: 33.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/3-retina {
     width: 66.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/4-retina {
     width: 25% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/4-retina {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-3\/4-retina {
     width: 75% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-1\/6-retina {
     width: 16.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-2\/6-retina {
     width: 33.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-3\/6-retina {
     width: 50% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-4\/6-retina {
     width: 66.6666666667% !important;
-    -ms-flex: none !important;
-        flex: none !important; }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; }
   .u-5\/6-retina {
     width: 83.3333333333% !important;
-    -ms-flex: none !important;
-        flex: none !important; } }
+    -webkit-flex: none !important;
+        -ms-flex: none !important;
+            flex: none !important; } }
 
 #tooltip {
   background-color: black;

--- a/demo.html
+++ b/demo.html
@@ -111,7 +111,7 @@
             <div id="hoverDivTop6" class="hover-tooltip">Tooltip contains lots of text
                 <px-tooltip
                     orientation="top"
-                    tooltip-message="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer imperdiet velit non risus pellentesque, id molestie velit varius. Integer ac nulla hendrerit, aliquet mauris vitae, varius augue. Nulla non turpis metus. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla consectetur tincidunt tincidunt. Suspendisse vitae turpis libero.">
+                    tooltip-message="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer imperdiet velit non risus pellentesque, id molestie velit varius. Integer ac nulla hendrerit, aliquet mauris vitae, varius augue. Nulla non turpis metus. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullaverylongwordthatshouldbebrokendownforthetooltiptofitcontent consectetur tincidunt tincidunt. Suspendisse vitae turpis libero.">
                 </px-tooltip>
             </div>
 

--- a/sass/px-tooltip-sketch.scss
+++ b/sass/px-tooltip-sketch.scss
@@ -54,6 +54,7 @@ $tooltip-max-width: 400px;
     color: $tooltip-text-color;
     max-width: $tooltip-max-width;
     white-space: normal;
+    overflow-wrap: break-word;
 
     h6 {
         margin: 0;


### PR DESCRIPTION
Fix for issue https://github.com/PredixDev/px-tooltip/issues/12

- Added `overflow-wrap: break-word;` to the tooltip styles (px-tooltip-sketch.scss) to force long words to wrap around.

Before change:
![screen shot 2016-06-15 at 5 31 13 pm](https://cloud.githubusercontent.com/assets/6137443/16102352/6a73525a-3323-11e6-868d-c568c0ff9a27.png)


After change:
![screen shot 2016-06-15 at 6 03 20 pm](https://cloud.githubusercontent.com/assets/6137443/16102360/7ebb562c-3323-11e6-944f-b8936930ec5f.png)

