### PR TITLE
open up the API

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,7 @@ v1.1.0
   * `listenEvents`
   * `unlistenEvents`
 * Make `setPosition` public
+* Change the watchdog so it doesn't trigger a re-layout, improving performance
 
 v1.0.6
 =================

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,8 +4,8 @@ v1.1.0
   * `opened`: drives the show/hide request
   * `visible`: indicates wether the tooltip is currently shown on screen
   * `requestShow`: show request happened but not shown on screen yet
-  * `ignoreTargetEvents`: prevents the tooltip from listening to the target events, making it easier to get full control of when is shows/hide
-* Open methods for listening/unlistening to target events:
+  * `ignoreTargetEvents`: prevents the tooltip from listening to the target events, making it easier to get full control over when it shows/hide
+* Make methods for listening/unlistening to target events public:
   * `listenEvents`
   * `unlistenEvents`
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,7 +3,7 @@ v1.1.0
 * Open the tooltip for programatic use through the following properties:
   * `opened`: drives the show/hide request
   * `visible`: indicates wether the tooltip is currently shown on screen
-  * `requestShow`: show request happened but not shown on screen yet
+  * `openRequested`: show request happened but not shown on screen yet
   * `ignoreTargetEvents`: prevents the tooltip from listening to the target events, making it easier to get full control over when it shows/hide
 * Make methods for listening/unlistening to target events public:
   * `listenEvents`

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,9 @@ v1.1.0
   * `visible`: indicates wether the tooltip is currently shown on screen
   * `requestShow`: show request happened but not shown on screen yet
   * `ignoreTargetEvents`: prevents the tooltip from listening to the target events, making it easier to get full control of when is shows/hide
+* Open methods for listening/unlistening to target events:
+  * `listenEvents`
+  * `unlistenEvents`
 
 v1.0.6
 =================

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,7 @@ v1.1.0
 * Make methods for listening/unlistening to target events public:
   * `listenEvents`
   * `unlistenEvents`
+* Make `setPosition` public
 
 v1.0.6
 =================

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,11 @@
+v1.1.0
+=================
+* Open the tooltip for programatic use through the following properties:
+  * `opened`: drives the show/hide request
+  * `visible`: indicates wether the tooltip is currently shown on screen
+  * `requestShow`: show request happened but not shown on screen yet
+  * `ignoreTargetEvents`: prevents the tooltip from listening to the target events, making it easier to get full control of when is shows/hide
+
 v1.0.6
 =================
 * add device flags

--- a/px-tooltip.html
+++ b/px-tooltip.html
@@ -337,7 +337,6 @@ Custom property | Description
             }
         } else {
             this.listen(this._target, 'mouseenter', '_setOpenedTrue');
-            this.listen(this._target, 'mouseenter', '_setOpenedTruee');
             this.listen(this._target, 'mouseup', '_setOpenedTrue');
             this.listen(this._target, 'mouseleave', '_setOpenedFalse');
             this.listen(this._target, 'mousedown', '_setOpenedFalse');
@@ -369,13 +368,7 @@ Custom property | Description
     },
 
     _setOpenedTrue: function() {
-      console.log('setOpenedTrue')
       this.set('opened', true);
-    },
-
-    _setOpenedTruee: function() {
-      console.log('setOpenedTrue2')
-
     },
 
     _setOpenedFalse: function() {

--- a/px-tooltip.html
+++ b/px-tooltip.html
@@ -893,7 +893,7 @@ Custom property | Description
 
         //shadow root
         if(current.nodeType === 11) {
-          current = current.host();
+          current = current.host;
         } else {
           current = current.parentNode;
         }

--- a/px-tooltip.html
+++ b/px-tooltip.html
@@ -176,7 +176,7 @@ Custom property | Description
         * helpful to catch edge states (i.e reclosing the tooltip after a show
         * request has been issued but the tooltip isn't visible yet)
         */
-      requestShow: {
+        openRequested: {
         type: Boolean,
         value: false,
         readOnly: true,
@@ -316,7 +316,7 @@ Custom property | Description
 
         //detached triggered by our show/hide system
         this._internalDetaching = false;
-        if(!this.requestShow) {
+        if(!this.openRequested) {
           this.fire('px-tooltip-hide', {target: this});
         }
       }
@@ -337,6 +337,7 @@ Custom property | Description
             }
         } else {
             this.listen(this._target, 'mouseenter', '_setOpenedTrue');
+            this.listen(this._target, 'mouseenter', '_setOpenedTruee');
             this.listen(this._target, 'mouseup', '_setOpenedTrue');
             this.listen(this._target, 'mouseleave', '_setOpenedFalse');
             this.listen(this._target, 'mousedown', '_setOpenedFalse');
@@ -368,7 +369,13 @@ Custom property | Description
     },
 
     _setOpenedTrue: function() {
+      console.log('setOpenedTrue')
       this.set('opened', true);
+    },
+
+    _setOpenedTruee: function() {
+      console.log('setOpenedTrue2')
+
     },
 
     _setOpenedFalse: function() {
@@ -376,11 +383,11 @@ Custom property | Description
     },
 
     _openedChanged: function() {
-      if(this.opened && (!this.visible || !this.requestShow)) {
+      if(this.opened && (!this.visible || !this.openRequested)) {
         this._show();
       }
 
-      if(!this.opened && (this.visible || this.requestShow)) {
+      if(!this.opened && (this.visible || this.openRequested)) {
         this._hide();
       }
     },
@@ -428,7 +435,7 @@ Custom property | Description
       if(this._watchDogEnabled) {
         //need that debounce for IE
         this.debounce('tooltip-resize', function() {
-          if(this.requestShow) {
+          if(this.openRequested) {
             this._processShow();
           } else if(this.visible) {
             this.setPosition();
@@ -478,7 +485,7 @@ Custom property | Description
       //we start out with _cancel being false, but if at any time during the timeout it's set to true, we cancel the whole thing.
       this.set('_cancel',false);
       //readonly prop
-      this._setRequestShow(true);
+      this._setOpenRequested(true);
 
       setTimeout(function() {
         if(this._cancel === true) {
@@ -518,7 +525,7 @@ Custom property | Description
         target: this
       });
       //readonly prop
-      this._setRequestShow(false);
+      this._setOpenRequested(false);
     },
     /**
      * Hide the tooltip, clear the timer, and move the tooltip back to whence
@@ -529,10 +536,10 @@ Custom property | Description
 
       // // hide this thing
       this.set('_cancel',true);
-      if (this.visible || this.requestShow) {
+      if (this.visible || this.openRequested) {
         this._watchDogEnabled = false;
         //readonly prop
-        this._setRequestShow(false);
+        this._setOpenRequested(false);
 
         //and we move the tooltip back to whence it came.
         //readonly prop
@@ -884,6 +891,23 @@ Custom property | Description
       position += window[pageXOrYOffset]; // factor in any window scrolling we've done
       return position;
     },
+
+    _isWithinDom: function(node) {
+      var current = node,
+          search = true;
+
+      while(current && current.nodeName !== 'BODY') {
+
+        //shadow root
+        if(current.nodeType === 11) {
+          current = current.host();
+        } else {
+          current = current.parentNode;
+        }
+      }
+
+      return !!current;
+    },
     /**
      * Watchdog when the tooltip is showing so it can be removed
      * if the parent is removed. Returns false when the tooltip is removed.
@@ -891,11 +915,7 @@ Custom property | Description
     _watchDog: function() {
 
       //try to figure out if target is still in the document
-      //can't use document.contains or walking up the tree because
-      //of shadow dom
-      var rect = this._currTarget.getBoundingClientRect();
-      if(rect.width === 0 && rect.height === 0 && rect.left === 0 &&
-      rect.right === 0 && rect.top === 0 && rect.bottom === 0) {
+      if(!this._isWithinDom(this._currTarget)) {
         this._watchDogEnabled = false;
 
         //IE can't remove
@@ -936,6 +956,8 @@ Custom property | Description
       //make sure the handlers are removed
       if(this.ignoreTargetEvents) {
         this.unlistenEvents();
+      } else {
+        this.listenEvents();
       }
     }
   });

--- a/px-tooltip.html
+++ b/px-tooltip.html
@@ -275,7 +275,8 @@ Custom property | Description
     },
     observers: [
       '_onMouseMove(mouseCoords.*)',
-      '_openedChanged(opened)'
+      '_openedChanged(opened)',
+      '_ignoreTargetEventsChanged(ignoreTargetEvents)'
     ],
     listeners: {
       'iron-resize': '_onIronResize'
@@ -349,7 +350,7 @@ Custom property | Description
      */
     unlistenEvents: function() {
 
-      if(this._target && !this.ignoreTargetEvents) {
+      if(this._target) {
         if(Array.isArray(this._target)){
           for(var i =0; i < this._target.length; i++){
             this.unlisten(this._target[i], 'mouseenter', '_setOpenedTrue');
@@ -928,6 +929,14 @@ Custom property | Description
       //style the arrow
       res += this._tooltipPos;
       return res;
+    },
+
+    _ignoreTargetEventsChanged: function() {
+
+      //make sure the handlers are removed
+      if(this.ignoreTargetEvents) {
+        this.unlistenEvents();
+      }
     }
   });
 </script>

--- a/px-tooltip.html
+++ b/px-tooltip.html
@@ -431,7 +431,7 @@ Custom property | Description
           if(this.requestShow) {
             this._processShow();
           } else if(this.visible) {
-            this._setPosition();
+            this.setPosition();
           }
         }, 50);
       }
@@ -512,7 +512,7 @@ Custom property | Description
 
       //readonly prop
       this._setVisible(true);
-      this._setPosition();
+      this.setPosition();
 
       this.fire('px-tooltip-show', {
         target: this
@@ -557,9 +557,9 @@ Custom property | Description
     },
     /**
      * This function calls the appropriate positioning function,
-     * according to the orientation specified.
+     * according to the orientation specified, target and tooltip content
      */
-    _setPosition: function() {
+    setPosition: function() {
       if(!this._target) {
         return;
       }
@@ -589,7 +589,7 @@ Custom property | Description
     /**
     * @method _autoPosition
     * This function is called as the default positioning
-    * in _setPosition
+    * in setPosition
     *
     */
     _autoPosition: function() {

--- a/px-tooltip.html
+++ b/px-tooltip.html
@@ -37,7 +37,7 @@ Custom property | Description
   <template>
     <style include="px-tooltip-styles"></style>
 
-    <div id="tooltip" class$="[[_getClass(_isShowing, _tooltipPos)]]">
+    <div id="tooltip" class$="[[_getClass(visible, _tooltipPos)]]">
       <div id="message">
         <span>{{ tooltipMessage }}</span>
         <content></content>
@@ -53,6 +53,7 @@ Custom property | Description
     behaviors: [
       Polymer.IronResizableBehavior
     ],
+
     /**
      * Private Properties, used in internal view logic.
      * @property _values
@@ -81,7 +82,7 @@ Custom property | Description
     * @event px-tooltip-request-show
     */
     /**
-    * Fired when a reuqest for hiding the tooltip has been started. At this point the tooltip
+    * Fired when a request for hiding the tooltip has been started. At this point the tooltip
     * has been visually hidden but still is in <body> and hasn't been moved back to where it
     * belongs in the dom
     * detail: { target: this}
@@ -137,6 +138,50 @@ Custom property | Description
         type: String,
         value: ''
       },
+
+      /**
+      * This boolean can be used to REQUEST an open/close action to the tooltip
+      * Because the show/hide mechanism are asynchronous this won't represent
+      * the actual presence of the tooltip on the screen, this is represented
+      * by the `visible` property
+      */
+      opened: {
+        type: Boolean,
+        value: false,
+        notify: true
+      },
+
+      /**
+        * Whether the tooltip is currently shown on screen
+        *
+        */
+      visible: {
+        type: Boolean,
+        value: false,
+        readOnly: true,
+        notify: true
+      },
+      /**
+        * If true the tooltip will ignore the targets events it usually listens
+        * to: mouseup/down, mouseleave/enter... Use this to more precisely
+        * manually control the showing/hiding of the tooltip
+        */
+      ignoreTargetEvents: {
+        type: Boolean,
+        value: false
+      },
+      /**
+        * True when opened has been requested (i.e set to true) but the tooltip
+        * hasn't been made visible yet. Not needed in most cases but might be
+        * helpful to catch edge states (i.e reclosing the tooltip after a show
+        * request has been issued but the tooltip isn't visible yet)
+        */
+      requestShow: {
+        type: Boolean,
+        value: false,
+        readOnly: true,
+        notify: true
+      },
       /**
        * If smartOrientation is turned on then the tooltip will override the
        * default orientation to try to better fit on the page. Smart Orientation
@@ -147,13 +192,6 @@ Custom property | Description
        * Note: this feature is only enabled for the "top" or "bottom" orientations
        */
       smartOrientation: {
-        type: Boolean,
-        value: false
-      },
-      /**
-       * Whether the tooltip is showing at the moment.
-       */
-      _isShowing: {
         type: Boolean,
         value: false
       },
@@ -213,10 +251,6 @@ Custom property | Description
         type: Boolean,
         value: false
       },
-      _requestShow: {
-        type: Boolean,
-        value: false
-      },
       /**
        * Used internally for calculations, includes carat + spacing from target (5+5)
        */
@@ -240,20 +274,23 @@ Custom property | Description
       }
     },
     observers: [
-      '_onMouseMove(mouseCoords.*)'
+      '_onMouseMove(mouseCoords.*)',
+      '_openedChanged(opened)'
     ],
     listeners: {
       'iron-resize': '_onIronResize'
     },
     attached: function() {
-      this.setAttribute('role','tooltip');
+
 
       if(this._firstAttached) {
+
+        this.setAttribute('role','tooltip');
         // we want to remember where this tooltip was placed originally.
         this.set('_tooltipParent', this.parentNode);
         // we want to make sure the target exists-
         if(this._target){
-          this._listenEvents();
+          this.listenEvents();
         }
         else {
           //make sure tooltip find its parent if it has no for
@@ -268,8 +305,8 @@ Custom property | Description
 
         //"genuine" detach. Ensure we call hide so that everything is reset and
         //ensuring the tooltip is put back were it should be
-        this._hide();
-        this._unlistenEvents();
+        this.set('opened', false);
+        this.unlistenEvents();
         this._target = null;
 
         //ensure we reset the flag so that we start re listening if we re-attach
@@ -278,55 +315,78 @@ Custom property | Description
 
         //detached triggered by our show/hide system
         this._internalDetaching = false;
-        if(!this._requestShow) {
+        if(!this.requestShow) {
           this.fire('px-tooltip-hide', {target: this});
         }
       }
     },
 
-    _listenEvents: function() {
-      if(this._target) {
+    /**
+    * Starts listening to all mouse events (on the target(s)) we are
+    * interested in: mouseenter, mouseup, mouseleave, mousedown
+    */
+    listenEvents: function() {
+      if(this._target && !this.ignoreTargetEvents) {
         if(Array.isArray(this._target)){
             for(var i =0; i < this._target.length; i++){
-              this.listen(this._target[i], 'mouseenter', '_show');
-              this.listen(this._target[i], 'mouseup', '_show');
-              this.listen(this._target[i], 'mouseleave', '_hide');
-              this.listen(this._target[i], 'mousedown', '_hide');
+              this.listen(this._target[i], 'mouseenter', '_setOpenedTrue');
+              this.listen(this._target[i], 'mouseup', '_setOpenedTrue');
+              this.listen(this._target[i], 'mouseleave', '_setOpenedFalse');
+              this.listen(this._target[i], 'mousedown', '_setOpenedFalse');
             }
         } else {
-            this.listen(this._target, 'mouseenter', '_show');
-            this.listen(this._target, 'mouseup', '_show');
-            this.listen(this._target, 'mouseleave', '_hide');
-            this.listen(this._target, 'mousedown', '_hide');
+            this.listen(this._target, 'mouseenter', '_setOpenedTrue');
+            this.listen(this._target, 'mouseup', '_setOpenedTrue');
+            this.listen(this._target, 'mouseleave', '_setOpenedFalse');
+            this.listen(this._target, 'mousedown', '_setOpenedFalse');
         }
       }
     },
 
     /**
-     * Stops listening to all mouse events we were interested in
+     * Stops listening to all mouse events (on the target(s)) we were interested
+     * in: mouseenter, mouseup, mouseleave, mousedown
      */
-    _unlistenEvents: function() {
+    unlistenEvents: function() {
 
-      if(this._target) {
+      if(this._target && !this.ignoreTargetEvents) {
         if(Array.isArray(this._target)){
           for(var i =0; i < this._target.length; i++){
-            this.unlisten(this._target[i], 'mouseenter', '_show');
-            this.unlisten(this._target[i], 'mouseup', '_show');
-            this.unlisten(this._target[i], 'mouseleave', '_hide');
-            this.unlisten(this._target[i], 'mousedown', '_hide');
+            this.unlisten(this._target[i], 'mouseenter', '_setOpenedTrue');
+            this.unlisten(this._target[i], 'mouseup', '_setOpenedTrue');
+            this.unlisten(this._target[i], 'mouseleave', '_setOpenedFalse');
+            this.unlisten(this._target[i], 'mousedown', '_setOpenedFalse');
           }
         } else {
-          this.unlisten(this._target, 'mouseenter', '_show');
-          this.unlisten(this._target, 'mouseup', '_show');
-          this.unlisten(this._target, 'mouseleave', '_hide');
-          this.unlisten(this._target, 'mousedown', '_hide');
+          this.unlisten(this._target, 'mouseenter', '_setOpenedTrue');
+          this.unlisten(this._target, 'mouseup', '_setOpenedTrue');
+          this.unlisten(this._target, 'mouseleave', '_setOpenedFalse');
+          this.unlisten(this._target, 'mousedown', '_setOpenedFalse');
         }
+      }
+    },
+
+    _setOpenedTrue: function() {
+      this.set('opened', true);
+    },
+
+    _setOpenedFalse: function() {
+      this.set('opened', false);
+    },
+
+    _openedChanged: function() {
+      if(this.opened && (!this.visible || !this.requestShow)) {
+        this._show();
+      }
+
+      if(!this.opened && (this.visible || this.requestShow)) {
+        this._hide();
       }
     },
 
     _onMouseMove: function(){
 
-      if(this.followMouse && this.thisRect && this._isShowing){
+      if(this.followMouse && this.thisRect && this.visible){
 
         if(this.orientation === 'auto') {
 
@@ -350,12 +410,12 @@ Custom property | Description
      * calls _getTarget and sets the target.
      */
     _onFor:function(){
-      this._unlistenEvents()
+      this.unlistenEvents()
 
       this.target = this._getTarget();
       this._target = this.target;
 
-      this._listenEvents();
+      this.listenEvents();
     },
     /**
      *  Make sure the tooltip is positioned properly if currently showing.
@@ -367,9 +427,9 @@ Custom property | Description
       if(this._watchDogEnabled) {
         //need that debounce for IE
         this.debounce('tooltip-resize', function() {
-          if(this._requestShow) {
+          if(this.requestShow) {
             this._processShow();
-          } else if(this._isShowing) {
+          } else if(this.visible) {
             this._setPosition();
           }
         }, 50);
@@ -409,13 +469,15 @@ Custom property | Description
      * This function sets a timeout with the delay value, and if
      * this.cancel has not been called, moves the tooltip to the DOM root,
      * and sets the tooltip as visible.
+     * Don't call this manually but set `opened` instead
      */
     _show: function(evt) {
       var _this = this,
           currTarget = Polymer.dom(evt).rootTarget;
       //we start out with _cancel being false, but if at any time during the timeout it's set to true, we cancel the whole thing.
       this.set('_cancel',false);
-      this._requestShow = true;
+      //readonly prop
+      this._setRequestShow(true);
 
       setTimeout(function() {
         if(this._cancel === true) {
@@ -447,27 +509,33 @@ Custom property | Description
         return;
       }
 
-      this.set('_isShowing', true);
+      //readonly prop
+      this._setVisible(true);
       this._setPosition();
 
       this.fire('px-tooltip-show', {
         target: this
       });
-      this._requestShow = false;
+      //readonly prop
+      this._setRequestShow(false);
     },
     /**
-     * Hide the tooltip, clear the timer, and move the tooltip back to whence it came.
+     * Hide the tooltip, clear the timer, and move the tooltip back to whence
+     * it came.
+     * Don't call this manually but set `opened` instead
      */
     _hide: function() {
 
       // // hide this thing
       this.set('_cancel',true);
-      if (this._isShowing || this._requestShow) {
+      if (this.visible || this.requestShow) {
         this._watchDogEnabled = false;
-        this._requestShow = false;
+        //readonly prop
+        this._setRequestShow(false);
 
         //and we move the tooltip back to whence it came.
-        this.set('_isShowing', false);
+        //readonly prop
+        this._setVisible(false);
 
         this.fire('px-tooltip-request-hide', {target: this});
         if(this._tooltipParent && this._tooltipParent.appendChild) {
@@ -480,7 +548,8 @@ Custom property | Description
           if(this.remove) {
             this.remove();
           } else {
-            this.set('_isShowing', false);
+            //readonly prop
+            this._setVisible('visible');
           }
         }
       }
@@ -832,7 +901,7 @@ Custom property | Description
         if(this.remove) {
           this.remove();
         } else {
-          this._hide()
+          this.set('opened', false);
         }
 
         //if target is an array make sure we remove it from the array
@@ -852,7 +921,7 @@ Custom property | Description
     _getClass: function() {
       var res = 'tooltip-container ';
 
-      if(!this._isShowing) {
+      if(!this.visible) {
         res += ' hidden ';
       }
 

--- a/test/px-tooltip-custom-tests.js
+++ b/test/px-tooltip-custom-tests.js
@@ -34,12 +34,12 @@ function runCustomTests() {
 
      test('when _show called', function(done) {
 
-      assert.isFalse(px_tooltip.requestShow);
+      assert.isFalse(px_tooltip.openRequested);
       px_tooltip.set('opened', true);
-      assert.isTrue(px_tooltip.requestShow);
+      assert.isTrue(px_tooltip.openRequested);
       setTimeout(function() {
           assert.isTrue(px_tooltip.visible);
-          assert.isFalse(px_tooltip.requestShow);
+          assert.isFalse(px_tooltip.openRequested);
           done();
       }, 1000); // delay is 500 ms
      });
@@ -86,12 +86,12 @@ suite('Custom Automation Tests for px-tooltip', function() {
 
      test('when _show called', function(done) {
 
-         assert.isFalse(px_tooltip.requestShow);
+         assert.isFalse(px_tooltip.openRequested);
          px_tooltip.set('opened', true);
-         assert.isTrue(px_tooltip.requestShow);
+         assert.isTrue(px_tooltip.openRequested);
          setTimeout(function() {
              assert.isTrue(px_tooltip.visible);
-             assert.isFalse(px_tooltip.requestShow);
+             assert.isFalse(px_tooltip.openRequested);
              done();
          }, 1000); // delay is 500 ms
      });

--- a/test/px-tooltip-custom-tests.js
+++ b/test/px-tooltip-custom-tests.js
@@ -11,7 +11,7 @@ function runCustomTests() {
     var px_tooltip = Polymer.dom(document).querySelector('#px_tooltip_1');
 
   test('hides tooltip before click', function() {
-    assert.isFalse(px_tooltip._isShowing);
+    assert.isFalse(px_tooltip.visible);
   });
 
   test('reflects the "for" property', function() {
@@ -19,7 +19,7 @@ function runCustomTests() {
   });
 
   test('reflects the "delay" property', function() {
-     assert.equal(px_tooltip.delay, 5000);
+     assert.equal(px_tooltip.delay, 500);
   });
 
   test('reflects the "orientation" property', function() {
@@ -32,12 +32,16 @@ function runCustomTests() {
 
    suite('when tooltip is shown', function() {
 
-     setup('when _show called', function(done) {
-         px_tooltip._show();
-         setTimeout(function() {
-             assert.isTrue(px_tooltip._isShowing);
-             done();
-         }, 3000); // delay is 500 ms
+     test('when _show called', function(done) {
+
+      assert.isFalse(px_tooltip.requestShow);
+      px_tooltip.set('opened', true);
+      assert.isTrue(px_tooltip.requestShow);
+      setTimeout(function() {
+          assert.isTrue(px_tooltip.visible);
+          assert.isFalse(px_tooltip.requestShow);
+          done();
+      }, 1000); // delay is 500 ms
      });
    });
   });
@@ -67,7 +71,7 @@ suite('Custom Automation Tests for px-tooltip', function() {
   px_tooltip_8.set('for',target);
 
   test('hides tooltip before click', function() {
-    assert.isFalse(px_tooltip._isShowing);
+    assert.isFalse(px_tooltip.visible);
   });
 
   test('"for" property is object', function() {
@@ -80,12 +84,16 @@ suite('Custom Automation Tests for px-tooltip', function() {
 
    suite('when tooltip is shown', function() {
 
-     setup('when _show called', function(done) {
-         px_tooltip._show();
+     test('when _show called', function(done) {
+
+         assert.isFalse(px_tooltip.requestShow);
+         px_tooltip.set('opened', true);
+         assert.isTrue(px_tooltip.requestShow);
          setTimeout(function() {
-             assert.isTrue(px_tooltip._isShowing);
+             assert.isTrue(px_tooltip.visible);
+             assert.isFalse(px_tooltip.requestShow);
              done();
-         }, 3000); // delay is 500 ms
+         }, 1000); // delay is 500 ms
      });
    });
   });

--- a/test/px-tooltip-test-fixture.html
+++ b/test/px-tooltip-test-fixture.html
@@ -29,7 +29,7 @@
         <px-tooltip
             for="hoverDivTop"
             orientation="top"
-            delay="5000"
+            delay="500"
             tooltip-message="Top tooltip"
             id="px_tooltip_1">
         </px-tooltip>


### PR DESCRIPTION
Opening up the API for easier programatic use. New properties:
* `opened`: drives the show/hide request
* `visible`: indicates wether the tooltip is currently shown on screen
* `requestShow`: show request happened but not shown on screen yet
* `ignoreTargetEvents`: prevents the tooltip from listening to the target events, making it easier to get full control of when is shows/hide

expose methods for listening/unlistenign to target events as well:
* `listenEvents`
* `unlistenEvents`